### PR TITLE
Hide generated serializers

### DIFF
--- a/file.go
+++ b/file.go
@@ -77,7 +77,11 @@ func (f *File) OpenRaw(r io.Reader) (io.Reader, error) {
 }
 
 // Files is a collection of files.
+//msgp:ignore Files
 type Files []File
+
+// unexported type to hide generated serialization functions.
+type files []File
 
 // Any changes to the file format MUST cause an increment here and MUST
 // be backwards compatible.
@@ -103,7 +107,7 @@ type filesAsStructs struct {
 // Serialize the files.
 func (f Files) Serialize() ([]byte, error) {
 	if len(f) < 10 {
-		payload, err := f.MarshalMsg(nil)
+		payload, err := files(f).MarshalMsg(nil)
 		if err != nil {
 			return nil, err
 		}
@@ -233,9 +237,9 @@ func DeserializeFiles(b []byte) (Files, error) {
 		return nil, err
 	}
 	if !structs {
-		var dst Files
+		var dst files
 		_, err = dst.UnmarshalMsg(b)
-		return dst, err
+		return Files(dst), err
 	}
 
 	var dst filesAsStructs

--- a/file_gen.go
+++ b/file_gen.go
@@ -260,7 +260,7 @@ func (z *File) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
-func (z *Files) DecodeMsg(dc *msgp.Reader) (err error) {
+func (z *files) DecodeMsg(dc *msgp.Reader) (err error) {
 	var zb0002 uint32
 	zb0002, err = dc.ReadArrayHeader()
 	if err != nil {
@@ -270,7 +270,7 @@ func (z *Files) DecodeMsg(dc *msgp.Reader) (err error) {
 	if cap((*z)) >= int(zb0002) {
 		(*z) = (*z)[:zb0002]
 	} else {
-		(*z) = make(Files, zb0002)
+		(*z) = make(files, zb0002)
 	}
 	for zb0001 := range *z {
 		err = (*z)[zb0001].DecodeMsg(dc)
@@ -283,7 +283,7 @@ func (z *Files) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z Files) EncodeMsg(en *msgp.Writer) (err error) {
+func (z files) EncodeMsg(en *msgp.Writer) (err error) {
 	err = en.WriteArrayHeader(uint32(len(z)))
 	if err != nil {
 		err = msgp.WrapError(err)
@@ -300,7 +300,7 @@ func (z Files) EncodeMsg(en *msgp.Writer) (err error) {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z Files) MarshalMsg(b []byte) (o []byte, err error) {
+func (z files) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
 	for zb0003 := range z {
@@ -314,7 +314,7 @@ func (z Files) MarshalMsg(b []byte) (o []byte, err error) {
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *Files) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *files) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var zb0002 uint32
 	zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
@@ -324,7 +324,7 @@ func (z *Files) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	if cap((*z)) >= int(zb0002) {
 		(*z) = (*z)[:zb0002]
 	} else {
-		(*z) = make(Files, zb0002)
+		(*z) = make(files, zb0002)
 	}
 	for zb0001 := range *z {
 		bts, err = (*z)[zb0001].UnmarshalMsg(bts)
@@ -338,7 +338,7 @@ func (z *Files) UnmarshalMsg(bts []byte) (o []byte, err error) {
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z Files) Msgsize() (s int) {
+func (z files) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
 	for zb0003 := range z {
 		s += z[zb0003].Msgsize()

--- a/file_gen_test.go
+++ b/file_gen_test.go
@@ -122,8 +122,8 @@ func BenchmarkDecodeFile(b *testing.B) {
 	}
 }
 
-func TestMarshalUnmarshalFiles(t *testing.T) {
-	v := Files{}
+func TestMarshalUnmarshalfiles(t *testing.T) {
+	v := files{}
 	bts, err := v.MarshalMsg(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -145,8 +145,8 @@ func TestMarshalUnmarshalFiles(t *testing.T) {
 	}
 }
 
-func BenchmarkMarshalMsgFiles(b *testing.B) {
-	v := Files{}
+func BenchmarkMarshalMsgfiles(b *testing.B) {
+	v := files{}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -154,8 +154,8 @@ func BenchmarkMarshalMsgFiles(b *testing.B) {
 	}
 }
 
-func BenchmarkAppendMsgFiles(b *testing.B) {
-	v := Files{}
+func BenchmarkAppendMsgfiles(b *testing.B) {
+	v := files{}
 	bts := make([]byte, 0, v.Msgsize())
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
@@ -166,8 +166,8 @@ func BenchmarkAppendMsgFiles(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmarshalFiles(b *testing.B) {
-	v := Files{}
+func BenchmarkUnmarshalfiles(b *testing.B) {
+	v := files{}
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
@@ -180,17 +180,17 @@ func BenchmarkUnmarshalFiles(b *testing.B) {
 	}
 }
 
-func TestEncodeDecodeFiles(t *testing.T) {
-	v := Files{}
+func TestEncodeDecodefiles(t *testing.T) {
+	v := files{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeFiles Msgsize() is inaccurate")
+		t.Log("WARNING: TestEncodeDecodefiles Msgsize() is inaccurate")
 	}
 
-	vn := Files{}
+	vn := files{}
 	err := msgp.Decode(&buf, &vn)
 	if err != nil {
 		t.Error(err)
@@ -204,8 +204,8 @@ func TestEncodeDecodeFiles(t *testing.T) {
 	}
 }
 
-func BenchmarkEncodeFiles(b *testing.B) {
-	v := Files{}
+func BenchmarkEncodefiles(b *testing.B) {
+	v := files{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))
@@ -218,8 +218,8 @@ func BenchmarkEncodeFiles(b *testing.B) {
 	en.Flush()
 }
 
-func BenchmarkDecodeFiles(b *testing.B) {
-	v := Files{}
+func BenchmarkDecodefiles(b *testing.B) {
+	v := files{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))


### PR DESCRIPTION
These provide no direct value and only cause confusion.